### PR TITLE
add protectedNamespaces setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ kubectl apply -k .
 
 ## Configuration
 
-See `settings.yaml`
+See `settings.yaml` as example
 
 ```yaml
 interval: "18000"  # 5h
@@ -32,8 +32,16 @@ ignoredResouces:
   - apiGroup: ""
     kind: ServiceAccount
     nameRegExp: default
+protectedNamespaces:
+  - protected-one
+  - default
+  - kube-public
+  - kube-system
 ```
 
 * `interval` - interval between namespaces check
 * `initialDelay` - 'grace period' before new namespace will be checked
 * `ignoredResouces` - namespace will be treated as empty if it contains only 'ignored resources'
+* `protectedNamespaces` - these namespaces will not be deleated dispite of emptiness
+
+Note that usually there is no need to add kubernetes default namespaces (`default`, `kube-public` and `kube-system`) to `protectedNamespaces` because they have some resources inside in the most cases. But you certainly can do it just to be sure that nothing will happen with them. Also, if your `kube-system` is empty you are probably it trouble already :)

--- a/manifests/deployment.yaml
+++ b/manifests/deployment.yaml
@@ -18,12 +18,12 @@ spec:
     spec:
       serviceAccountName: remove-empty-ns-operator
       containers:
-      - name: remove-empty-ns-operator
-        image: rgeraskin/remove-empty-ns-operator:1.0
-        volumeMounts:
-        - name: config
-          mountPath: /config
+        - name: remove-empty-ns-operator
+          image: rgeraskin/remove-empty-ns-operator:1.1
+          volumeMounts:
+            - name: config
+              mountPath: /config
       volumes:
-      - name: config
-        configMap:
-          name: remove-empty-ns-operator
+        - name: config
+          configMap:
+            name: remove-empty-ns-operator

--- a/settings.yaml
+++ b/settings.yaml
@@ -13,3 +13,8 @@ ignoredResouces:
   - apiGroup: ""
     kind: ServiceAccount
     nameRegExp: default
+protectedNamespaces:
+  - protected-one
+  - default
+  - kube-public
+  - kube-system

--- a/src/remove-empty-ns-operator.py
+++ b/src/remove-empty-ns-operator.py
@@ -19,9 +19,13 @@ interval = int(settings["interval"])
 
 initial_delay = int(settings["initialDelay"])
 ignored_resouces = settings["ignoredResouces"]
+protected_namespaces = settings.get("protectedNamespaces", [])
 
 
-@kopf.timer('namespaces', interval=interval, initial_delay=initial_delay)
+@kopf.timer('namespaces',
+            interval=interval,
+            initial_delay=initial_delay,
+            when=lambda name, **_: name not in protected_namespaces)
 def remove_empty_ns(status, name, body, logger, **kwargs):
     global core_api
     meta = body["metadata"]


### PR DESCRIPTION
```
protectedNamespaces:
  - protected-one
  - default
  - kube-public
  - kube-system
```

Usually there is no need to add kubernetes default namespaces (`default`, `kube-public` and `kube-system`) to `protectedNamespaces` because they have some resources inside in the most cases. But you certainly can do it just to be sure that nothing will happen with them.

closes #1 