### PR TITLE
Increase PyYAML version

### DIFF
--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -19,7 +19,7 @@ pyasn1==0.4.8
 pyasn1-modules==0.2.8
 python-dateutil==2.8.2
 python-json-logger==2.0.2
-PyYAML==6.0
+PyYAML==6.0.1
 requests==2.28.1
 requests-oauthlib==1.3.1
 rsa==4.8


### PR DESCRIPTION
PyYAML version 6.0 seems broken with new Cython version, increasing version to 6.0.1 fix the issue.